### PR TITLE
Remove double loading of level music

### DIFF
--- a/src/gradience/states/levels/base.js
+++ b/src/gradience/states/levels/base.js
@@ -35,7 +35,6 @@ BaseLevel.prototype = {
         UI.create(this);
         this.add.audio('intro', 1).play();
         this.music = this.add.audio('music', 1, true).play();
-        this.bells = this.add.audio('bells', 1, true).play();
 
         this.backdrop = new Environment.Backdrop(this.game);
 

--- a/src/gradience/states/title.js
+++ b/src/gradience/states/title.js
@@ -90,13 +90,6 @@ TitleState.prototype = {
             ]
         );
         this.load.audio(
-            'bells',
-            [
-                'assets/audio/level1.mp3',
-                'assets/audio/level1.opus'
-            ]
-        );
-        this.load.audio(
             'gameover',
             [
                 'assets/audio/game-over.mp3',


### PR DESCRIPTION
Quick fix to only load and play one instance of in-game music.
