### PR TITLE
Use level 1 music in all stages

### DIFF
--- a/assets/levels/level_1.yaml
+++ b/assets/levels/level_1.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true

--- a/assets/levels/level_2.yaml
+++ b/assets/levels/level_2.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true

--- a/assets/levels/level_3.yaml
+++ b/assets/levels/level_3.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true

--- a/assets/levels/level_sandbox.yaml
+++ b/assets/levels/level_sandbox.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true

--- a/assets/levels/sandbox.yaml
+++ b/assets/levels/sandbox.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true

--- a/assets/levels/tutorial_2.yaml
+++ b/assets/levels/tutorial_2.yaml
@@ -11,8 +11,8 @@ level:
             - enemy_ship: assets/sprites/enemy_ship.png
         audio: !!pairs
             - music:
-                - assets/audio/backing-bell.mp3
-                - assets/audio/backing-bell.opus
+                - assets/audio/level1.mp3
+                - assets/audio/level1.opus
     flags:
         unlimitedAmmo: false
         collectibles: true


### PR DESCRIPTION
Fix to use level1 music in all stages in place of the temporary bell.
